### PR TITLE
fix(variable): Fix for ternary type mismatch and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Available targets:
 | <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | Number of days you want to retain log events in the log group | `string` | `"30"` | no |
 | <a name="input_root_common_name"></a> [root\_common\_name](#input\_root\_common\_name) | Unique Common Name for Root self-signed certificate | `string` | `null` | no |
 | <a name="input_saml_metadata_document"></a> [saml\_metadata\_document](#input\_saml\_metadata\_document) | Optional SAML metadata document. Must include this or `saml_provider_arn` | `string` | `null` | no |
-| <a name="input_saml_provider_arn"></a> [saml\_provider\_arn](#input\_saml\_provider\_arn) | Optional SAML provider ARN. Must include this or `saml_metadata_document` | `string` | `""` | no |
+| <a name="input_saml_provider_arn"></a> [saml\_provider\_arn](#input\_saml\_provider\_arn) | Optional SAML provider ARN. Must include this or `saml_metadata_document` | `string` | `null` | no |
 | <a name="input_server_common_name"></a> [server\_common\_name](#input\_server\_common\_name) | Unique Common Name for Server self-signed certificate | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -70,7 +70,7 @@
 | <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | Number of days you want to retain log events in the log group | `string` | `"30"` | no |
 | <a name="input_root_common_name"></a> [root\_common\_name](#input\_root\_common\_name) | Unique Common Name for Root self-signed certificate | `string` | `null` | no |
 | <a name="input_saml_metadata_document"></a> [saml\_metadata\_document](#input\_saml\_metadata\_document) | Optional SAML metadata document. Must include this or `saml_provider_arn` | `string` | `null` | no |
-| <a name="input_saml_provider_arn"></a> [saml\_provider\_arn](#input\_saml\_provider\_arn) | Optional SAML provider ARN. Must include this or `saml_metadata_document` | `string` | `""` | no |
+| <a name="input_saml_provider_arn"></a> [saml\_provider\_arn](#input\_saml\_provider\_arn) | Optional SAML provider ARN. Must include this or `saml_metadata_document` | `string` | `null` | no |
 | <a name="input_server_common_name"></a> [server\_common\_name](#input\_server\_common\_name) | Unique Common Name for Server self-signed certificate | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   enabled                    = module.this.enabled
   mutual_enabled             = var.authentication_type == "certificate-authentication"
   federated_enabled          = var.authentication_type == "federated-authentication"
-  saml_provider_arn          = local.federated_enabled ? try(aws_iam_saml_provider.default.*.arn, var.saml_provider_arn) : ""
+  saml_provider_arn          = local.federated_enabled ? try(join("", aws_iam_saml_provider.default.*.arn), var.saml_provider_arn) : null
   root_certificate_chain_arn = local.mutual_enabled ? module.self_signed_cert_ca.certificate_pem : null
   cloudwatch_log_group       = var.logging_enabled ? module.cloudwatch_log.log_group_name : null
   cloudwatch_log_stream      = var.logging_enabled ? var.logging_stream_name : null

--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ variable "saml_metadata_document" {
 }
 
 variable "saml_provider_arn" {
-  default     = ""
+  default     = null
   description = "Optional SAML provider ARN. Must include this or `saml_metadata_document`"
   type        = string
 
@@ -88,7 +88,7 @@ variable "saml_provider_arn" {
     condition = (
       var.saml_provider_arn == null ||
       try(length(regexall(
-        "^arn:[^:]+:iam::(?P<account_id>\\d{12}):saml-provider/(?P<provider_name>[\\w+=,\\.@-]+)$",
+        "^arn:[^:]+:iam::(?P<account_id>\\d{12}):saml-provider\\/(?P<provider_name>[\\w+=,\\.@-]+)$",
         var.saml_provider_arn
         )) > 0,
         false


### PR DESCRIPTION
## what
* Fix for 
```
│ Error: Inconsistent conditional result types
│
│   on .terraform/modules/ec2_client_vpn/main.tf line 9, in locals:
│    9:   saml_provider_arn          = local.federated_enabled ? try(aws_iam_saml_provider.default.*.arn, var.saml_provider_arn) : ""
│     ├────────────────
│     │ aws_iam_saml_provider.default is empty tuple
│     │ local.federated_enabled is false
│     │ var.saml_provider_arn is null
│

│ The true and false result expressions must have consistent types. The given expressions are tuple and string, respectively.
```

## why
* Error prevents deploying in infrastructure repository

## references
* N/A

