### PR TITLE
fix(templating): Fixes to how templating and output is handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ Available targets:
 | <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.8.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
@@ -200,7 +199,6 @@ Available targets:
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 | <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.8.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 
 ## Modules
 
@@ -222,7 +220,6 @@ Available targets:
 | [aws_ec2_client_vpn_network_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_network_association) | resource |
 | [aws_ec2_client_vpn_route.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_route) | resource |
 | [aws_iam_saml_provider.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_saml_provider) | resource |
-| [random_pet.vpn_host](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_ssm_parameter.ca_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.root_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [awsutils_ec2_client_vpn_export_client_config.default](https://registry.terraform.io/providers/cloudposse/awsutils/latest/docs/data-sources/ec2_client_vpn_export_client_config) | data source |
@@ -241,7 +238,7 @@ Available targets:
 | <a name="input_basic_constraints"></a> [basic\_constraints](#input\_basic\_constraints) | The [basic constraints](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9) of the issued certificate.<br>Currently, only the `CA` constraint (which identifies whether the subject of the certificate is a CA) can be set.<br>Defaults to this certificate not being a CA. | <pre>object({<br>    ca = bool<br>  })</pre> | <pre>{<br>  "ca": false<br>}</pre> | no |
 | <a name="input_ca_common_name"></a> [ca\_common\_name](#input\_ca\_common\_name) | Unique Common Name for CA self-signed certificate | `string` | `null` | no |
 | <a name="input_client_cidr"></a> [client\_cidr](#input\_client\_cidr) | Network CIDR to use for clients | `any` | n/a | yes |
-| <a name="input_client_configuration_template_path"></a> [client\_configuration\_template\_path](#input\_client\_configuration\_template\_path) | Path to template file of vpn client exported configuration. Path is relative to ${path.module} | `string` | `"templates/client-config.ovpn.tpl"` | no |
+| <a name="input_client_conf_tmpl_path"></a> [client\_conf\_tmpl\_path](#input\_client\_conf\_tmpl\_path) | Path to template file of vpn client exported configuration. Path is relative to ${path.module} | `string` | `null` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -8,7 +8,6 @@
 | <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.8.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
@@ -16,7 +15,6 @@
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 | <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.8.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 
 ## Modules
 
@@ -38,7 +36,6 @@
 | [aws_ec2_client_vpn_network_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_network_association) | resource |
 | [aws_ec2_client_vpn_route.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_route) | resource |
 | [aws_iam_saml_provider.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_saml_provider) | resource |
-| [random_pet.vpn_host](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_ssm_parameter.ca_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.root_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [awsutils_ec2_client_vpn_export_client_config.default](https://registry.terraform.io/providers/cloudposse/awsutils/latest/docs/data-sources/ec2_client_vpn_export_client_config) | data source |
@@ -57,7 +54,7 @@
 | <a name="input_basic_constraints"></a> [basic\_constraints](#input\_basic\_constraints) | The [basic constraints](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9) of the issued certificate.<br>Currently, only the `CA` constraint (which identifies whether the subject of the certificate is a CA) can be set.<br>Defaults to this certificate not being a CA. | <pre>object({<br>    ca = bool<br>  })</pre> | <pre>{<br>  "ca": false<br>}</pre> | no |
 | <a name="input_ca_common_name"></a> [ca\_common\_name](#input\_ca\_common\_name) | Unique Common Name for CA self-signed certificate | `string` | `null` | no |
 | <a name="input_client_cidr"></a> [client\_cidr](#input\_client\_cidr) | Network CIDR to use for clients | `any` | n/a | yes |
-| <a name="input_client_configuration_template_path"></a> [client\_configuration\_template\_path](#input\_client\_configuration\_template\_path) | Path to template file of vpn client exported configuration. Path is relative to ${path.module} | `string` | `"templates/client-config.ovpn.tpl"` | no |
+| <a name="input_client_conf_tmpl_path"></a> [client\_conf\_tmpl\_path](#input\_client\_conf\_tmpl\_path) | Path to template file of vpn client exported configuration. Path is relative to ${path.module} | `string` | `null` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,6 +2,10 @@ provider "aws" {
   region = var.region
 }
 
+provider "awsutils" {
+  region = var.region
+}
+
 locals {
   additional_routes = [for route in var.additional_routes : {
     destination_cidr_block = route.destination_cidr_block

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ locals {
   ca_common_name             = var.ca_common_name != null ? var.ca_common_name : "${module.this.id}.vpn.ca"
   root_common_name           = var.root_common_name != null ? var.root_common_name : "${module.this.id}.vpn.client"
   server_common_name         = var.server_common_name != null ? var.server_common_name : "${module.this.id}.vpn.server"
+  client_conf_tmpl_path      = var.client_conf_tmpl_path == null ? "${path.module}/templates/client-config.ovpn.tpl" : var.client_conf_tmpl_path
 }
 
 module "self_signed_cert_ca" {
@@ -225,10 +226,6 @@ data "awsutils_ec2_client_vpn_export_client_config" "default" {
   depends_on = [
     aws_ec2_client_vpn_endpoint.default
   ]
-}
-
-resource "random_pet" "vpn_host" {
-  length = "2"
 }
 
 data "aws_ssm_parameter" "root_key" {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-provider "awsutils" {
-  region = var.region
-}
-
 locals {
   enabled                    = module.this.enabled
   certificate_backends       = ["ACM", "SSM"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,14 +20,14 @@ output "client_configuration" {
 
 output "full_client_configuration" {
   value = var.export_client_certificate ? templatefile(
-    "${path.module}/${var.client_configuration_template_path}",
+    local.client_conf_tmpl_path,
     {
       cert        = module.self_signed_cert_root.certificate_pem,
       private_key = join("", data.aws_ssm_parameter.root_key.*.value)
       original_client_config = replace(
         data.awsutils_ec2_client_vpn_export_client_config.default.client_configuration,
         "remote cvpn",
-        "remote ${random_pet.vpn_host.id}.cvpn"
+        "remote ${module.this.id}.cvpn"
       )
     }
   ) : ""

--- a/variables.tf
+++ b/variables.tf
@@ -159,8 +159,8 @@ variable "export_client_certificate" {
   description = "Flag to determine whether to export the client certificate with the VPN configuration"
 }
 
-variable "client_configuration_template_path" {
-  default     = "templates/client-config.ovpn.tpl"
+variable "client_conf_tmpl_path" {
+  default     = null
   type        = string
   description = "Path to template file of vpn client exported configuration. Path is relative to $${path.module}"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -18,9 +18,5 @@ terraform {
       source  = "hashicorp/null"
       version = ">= 2.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.1.0"
-    }
   }
 }


### PR DESCRIPTION
## what
* Remove `random_pet` usage
* Change templating to allow users to bring their own templates
* Removed `awsutils` provider statement so it can be configured through module usage

## why
* Better flexibility with templates
* More generic naming of endpoints

## references
* N/A

