### PR TITLE
Restore automatic github/update

### DIFF
--- a/.github/.github-update-disabled
+++ b/.github/.github-update-disabled
@@ -1,3 +1,0 @@
-This presence of a .github/.github-update-disabled file
-prevents `make github/update` from making any changes.
-The contents of the file are ignored.


### PR DESCRIPTION
## what
- Restore automatic github/update

## why
- Included in #35 was an update to `auto-readme` to be used to validate the fix. In order to keep the fix from being reverted by `pr/auto-format`, the PR included a file to prevent auto-updates to workflows. Now that the fix is part of the auto update, we can and should restore auto-updates to this project.

## references
- https://github.com/cloudposse/build-harness/pull/312
- https://github.com/cloudposse/build-harness/releases/tag/0.62.2
