### PR TITLE
Add longer timeouts to aws_ec2_client_vpn_route

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -252,7 +252,7 @@ resource "aws_ec2_client_vpn_route" "default" {
   depends_on = [
     aws_ec2_client_vpn_network_association.default
   ]
-  
+
   timeouts {
     create = "5m"
     update = "5m"

--- a/main.tf
+++ b/main.tf
@@ -255,7 +255,6 @@ resource "aws_ec2_client_vpn_route" "default" {
 
   timeouts {
     create = "5m"
-    update = "5m"
     delete = "5m"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -252,6 +252,12 @@ resource "aws_ec2_client_vpn_route" "default" {
   depends_on = [
     aws_ec2_client_vpn_network_association.default
   ]
+  
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 
 data "awsutils_ec2_client_vpn_export_client_config" "default" {


### PR DESCRIPTION
Default timeout for `aws_ec2_client_vpn_route` is 1 minute for all operations.

Trying to attach routes in `eu-central-1` for a peered VPC, it constantly fails with:

```
│ Error: error waiting for EC2 Client VPN Route (cvpn-endpoint-xxx,subnet-yyy,10.100.0.0/16) create: timeout while waiting for state to become 'active' (last state: 'creating', timeout: 1m0s)
│ 
│   with module.ec2_client_vpn[0].aws_ec2_client_vpn_route.default[0],
│   on .terraform/modules/ec2_client_vpn/main.tf line 242, in resource "aws_ec2_client_vpn_route" "default":
│  242: resource "aws_ec2_client_vpn_route" "default" {
```

and 

```
│ Error: error waiting for EC2 Client VPN Route (cvpn-endpoint-xxx,subnet-yyy,10.100.0.0/16) delete: timeout while waiting for resource to be gone (last state: 'deleting', timeout: 1m0s)
```

With this commit, we increment the timeout to 5 minutes. In my experiments, the route is always available in around 90 seconds. 5 minutes gives us plenty of time, and still is not too long to wait in case of problems.

Upstream issue: https://github.com/hashicorp/terraform-provider-aws/issues/23787

I think fixing here is good, until we wait for an upstream improvement, because I am currently blocked

## what
* Increase Terraform timeouts for `aws_ec2_client_vpn_route`

## why
* Route creation fails constantly due to timeout, leaving the resources tainted

## references
* https://github.com/hashicorp/terraform-provider-aws/issues/23787

