### PR TITLE
Mark 'full_client_configuration' output as sensitive value

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,4 +32,5 @@ output "full_client_configuration" {
     }
   ) : ""
   description = "Client configuration including client certificate and private key"
+  sensitive = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,5 +32,5 @@ output "full_client_configuration" {
     }
   ) : ""
   description = "Client configuration including client certificate and private key"
-  sensitive = true
+  sensitive   = true
 }


### PR DESCRIPTION
## what
* Add `sensitive=true` option to `full_client_configuration` in `outputs.tf`.

## why
* While using `export_client_certificate = true` we're unable to retrieve the `full_client_configuration` output, because in newer versions of Terraform there is a strict requirement for sensitive outputs to be configured as `sensitive=true`.

