### PR TITLE
Use sg ids argument, rm deprecated input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -175,6 +175,11 @@ resource "aws_ec2_client_vpn_endpoint" "default" {
 
   session_timeout_hours = var.session_timeout_hours
 
+  security_group_ids = compact(concat(
+    [module.vpn_security_group.id],
+    local.associated_security_group_ids
+  ))
+
   tags = module.this.tags
 
   depends_on = [
@@ -224,11 +229,6 @@ resource "aws_ec2_client_vpn_network_association" "default" {
 
   client_vpn_endpoint_id = join("", aws_ec2_client_vpn_endpoint.default.*.id)
   subnet_id              = var.associated_subnets[count.index]
-
-  security_groups = compact(concat(
-    [module.vpn_security_group.id],
-    local.associated_security_group_ids
-  ))
 }
 
 resource "aws_ec2_client_vpn_authorization_rule" "default" {


### PR DESCRIPTION
## what
* Use sg ids argument, rm deprecated input

## why
```hcl
│ Warning: Argument is deprecated
│
│   with module.ec2_client_vpn.aws_ec2_client_vpn_network_association.default,
│   on .terraform/modules/ec2_client_vpn/main.tf line 228, in resource "aws_ec2_client_vpn_network_association" "default":
│  228:   security_groups = compact(concat(
│  229:     [module.vpn_security_group.id],
│  230:     local.associated_security_group_ids
│  231:   ))
│
│ Use the `security_group_ids` attribute of the `aws_ec2_client_vpn_endpoint` resource instead.
│
│ (and one more similar warning elsewhere)
```

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_network_association
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_endpoint

