### PR TITLE
Updating security group attachment location due to deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ec2-client-vpn&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ec2-client-vpn&utm_content=website
@@ -491,3 +491,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-ec2-client-vpn
   [share_email]: mailto:?subject=terraform-aws-ec2-client-vpn&body=https://github.com/cloudposse/terraform-aws-ec2-client-vpn
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-ec2-client-vpn?pixel&cs=github&cm=readme&an=terraform-aws-ec2-client-vpn
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -181,6 +181,11 @@ resource "aws_ec2_client_vpn_endpoint" "default" {
     module.self_signed_cert_server,
     module.self_signed_cert_root,
   ]
+
+  security_group_ids = compact(concat(
+    [module.vpn_security_group.id],
+    local.associated_security_group_ids
+  ))
 }
 
 module "vpn_security_group" {
@@ -224,11 +229,6 @@ resource "aws_ec2_client_vpn_network_association" "default" {
 
   client_vpn_endpoint_id = join("", aws_ec2_client_vpn_endpoint.default.*.id)
   subnet_id              = var.associated_subnets[count.index]
-
-  security_groups = compact(concat(
-    [module.vpn_security_group.id],
-    local.associated_security_group_ids
-  ))
 }
 
 resource "aws_ec2_client_vpn_authorization_rule" "default" {

--- a/main.tf
+++ b/main.tf
@@ -186,6 +186,7 @@ resource "aws_ec2_client_vpn_endpoint" "default" {
     [module.vpn_security_group.id],
     local.associated_security_group_ids
   ))
+  vpc_id = var.vpc_id
 }
 
 module "vpn_security_group" {


### PR DESCRIPTION
## what
* This addresses the deprecation notice currently being output as a result of using this module.

## why
* The argument is deprecated on the `aws_ec2_client_vpn_network_association` resource and will be removed in the near future.
<img width="984" alt="image" src="https://user-images.githubusercontent.com/20360959/191635811-50eba421-a691-4fc8-8b0e-7d185349a0d9.png">

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_network_association
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_endpoint

