### PR TITLE
Fork CloudPossee VPN Module with Fixes

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,0 +1,2 @@
+version: 1
+module_version: 0.16.1


### PR DESCRIPTION
Do some basic "fixes" to the cloudpossee module, which just remove some more complex logic to avoid the "multi-apply" issue. 

This primarily revolves around the module's extensive use of `count = <someBool> ? <some value> : some value`, which typically breaks terraform because `someBool` hasn't yet been applied

Hosting this fork in spacelift: https://rvshare.app.spacelift.io/module/terraform-aws-ec2-client-vpn