### PR TITLE
Updated the version of cloudposse/ssm-tls-self-signed-cert/aws" to 1.3.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ locals {
 
 module "self_signed_cert_ca" {
   source  = "cloudposse/ssm-tls-self-signed-cert/aws"
-  version = "1.1.0"
+  version = "1.3.0"
 
   attributes = ["self", "signed", "cert", "ca"]
 
@@ -58,7 +58,7 @@ data "aws_ssm_parameter" "ca_key" {
 
 module "self_signed_cert_root" {
   source  = "cloudposse/ssm-tls-self-signed-cert/aws"
-  version = "1.0.0"
+  version = "1.3.0"
 
   attributes = ["self", "signed", "cert", "root"]
 
@@ -95,7 +95,7 @@ module "self_signed_cert_root" {
 
 module "self_signed_cert_server" {
   source  = "cloudposse/ssm-tls-self-signed-cert/aws"
-  version = "1.0.0"
+  version = "1.3.0"
 
   attributes = ["self", "signed", "cert", "server"]
 

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     awsutils = {
       source  = "cloudposse/awsutils"
-      version = ">= 0.8.0"
+      version = ">= 0.16.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     awsutils = {
       source  = "cloudposse/awsutils"
-      version = ">= 0.16.0"
+      version = ">= 0.8.0"
     }
   }
 }


### PR DESCRIPTION
## what

Updated the version of referenced module `cloudposse/ssm-tls-self-signed-cert/aws` to 1.3.0

## why

The current versions referenced in this module use an older version that does not allow the more recently released tls provider to be used. This causes conflicts if trying to add this module to an environment were a 4.0.x version of the tls provider was already used, which would happen easily since that is the current version. 

## references
`closes #79`
