### PR TITLE
Upgrade awsutils provider version to 0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,14 +154,14 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
-| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.16.0 |
+| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.19.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
-| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.16.0 |
+| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.19.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,14 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
-| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.16.0 |
+| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.19.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
-| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.16.0 |
+| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.19.0 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     awsutils = {
       source  = "cloudposse/awsutils"
-      version = ">= 0.16.0"
+      version = ">= 0.19.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     awsutils = {
       source  = "cloudposse/awsutils"
-      version = ">= 0.16.0"
+      version = ">= 0.19.0"
     }
   }
 }


### PR DESCRIPTION
## what

Upgrade the version of the `awsutils` provider to `0.19.0`.

## why

 In order to enable usage of AWS IAM Identity center with the provider. Running terraform plan with the IAM Identity Center (SSO) was not enabled on the `0.16.0` version of the `awsutils` provider, and that is fixed with the `0.19.0`.

## references

https://github.com/cloudposse/terraform-provider-awsutils/releases/tag/0.19.0
