### PR TITLE
feat: Add cloudwatch and security group outputs

### DIFF
--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,20 +1,51 @@
-output "vpn_endpoint_arn" {
-  description = "The Amazon Resource Name (ARN) of the Client VPN endpoint"
-  value       = module.ec2_client_vpn.vpn_endpoint_arn
+output "client_configuration" {
+  sensitive   = true
+  value       = module.ec2_client_vpn.client_configuration
+  description = "VPN Client Configuration data."
 }
 
-output "vpn_endpoint_id" {
-  description = "The ID of the Client VPN endpoint"
-  value       = module.ec2_client_vpn.vpn_endpoint_id
+output "full_client_configuration" {
+  sensitive   = true
+  value       = module.ec2_client_vpn.full_client_configuration
+  description = "Client configuration including client certificate and private key"
+}
+
+output "log_group_arn" {
+  value       = module.ec2_client_vpn.log_group_arn
+  description = "The ARN of the CloudWatch Log Group used for Client VPN connection logging."
+}
+
+output "log_group_name" {
+  value       = module.ec2_client_vpn.log_group_name
+  description = "The name of the CloudWatch Log Group used for Client VPN connection logging."
+}
+
+output "security_group_arn" {
+  value       = module.ec2_client_vpn.security_group_arn
+  description = "The ARN of the security group associated with the Client VPN endpoint."
+}
+
+output "security_group_id" {
+  value       = module.ec2_client_vpn.security_group_id
+  description = "The ID of the security group associated with the Client VPN endpoint."
+}
+
+output "security_group_name" {
+  value       = module.ec2_client_vpn.security_group_name
+  description = "The name of the security group associated with the Client VPN endpoint."
+}
+
+output "vpn_endpoint_arn" {
+  value       = module.ec2_client_vpn.vpn_endpoint_arn
+  description = "The ARN of the Client VPN Endpoint Connection."
 }
 
 output "vpn_endpoint_dns_name" {
-  description = "The DNS name to be used by clients when establishing their VPN session"
   value       = module.ec2_client_vpn.vpn_endpoint_dns_name
+  description = "The DNS Name of the Client VPN Endpoint Connection."
 }
 
-output "client_configuration" {
-  description = "The full client configuration file content for the VPN endpoint"
-  sensitive   = true
-  value       = module.ec2_client_vpn.full_client_configuration
+output "vpn_endpoint_id" {
+  value       = module.ec2_client_vpn.vpn_endpoint_id
+  description = "The ID of the Client VPN Endpoint Connection."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,18 +1,3 @@
-output "vpn_endpoint_arn" {
-  value       = local.enabled ? join("", aws_ec2_client_vpn_endpoint.default[*].arn) : null
-  description = "The ARN of the Client VPN Endpoint Connection."
-}
-
-output "vpn_endpoint_id" {
-  value       = local.enabled ? join("", aws_ec2_client_vpn_endpoint.default[*].id) : null
-  description = "The ID of the Client VPN Endpoint Connection."
-}
-
-output "vpn_endpoint_dns_name" {
-  value       = local.enabled ? join("", aws_ec2_client_vpn_endpoint.default[*].dns_name) : null
-  description = "The DNS Name of the Client VPN Endpoint Connection."
-}
-
 output "client_configuration" {
   value       = local.enabled ? join("", data.awsutils_ec2_client_vpn_export_client_config.default[*].client_configuration) : null
   description = "VPN Client Configuration data."
@@ -33,4 +18,44 @@ output "full_client_configuration" {
   ) : ""
   description = "Client configuration including client certificate and private key"
   sensitive   = true
+}
+
+output "log_group_arn" {
+  value       = local.logging_enabled ? module.cloudwatch_log.log_group_arn : null
+  description = "The ARN of the CloudWatch Log Group used for Client VPN connection logging."
+}
+
+output "log_group_name" {
+  value       = local.logging_enabled ? module.cloudwatch_log.log_group_name : null
+  description = "The name of the CloudWatch Log Group used for Client VPN connection logging."
+}
+
+output "security_group_arn" {
+  value       = local.security_group_enabled ? module.vpn_security_group.arn : null
+  description = "The ARN of the security group associated with the Client VPN endpoint."
+}
+
+output "security_group_id" {
+  value       = local.security_group_enabled ? module.vpn_security_group.id : null
+  description = "The ID of the security group associated with the Client VPN endpoint."
+}
+
+output "security_group_name" {
+  value       = local.security_group_enabled ? module.vpn_security_group.name : null
+  description = "The name of the security group associated with the Client VPN endpoint."
+}
+
+output "vpn_endpoint_arn" {
+  value       = local.enabled ? join("", aws_ec2_client_vpn_endpoint.default[*].arn) : null
+  description = "The ARN of the Client VPN Endpoint Connection."
+}
+
+output "vpn_endpoint_dns_name" {
+  value       = local.enabled ? join("", aws_ec2_client_vpn_endpoint.default[*].dns_name) : null
+  description = "The DNS Name of the Client VPN Endpoint Connection."
+}
+
+output "vpn_endpoint_id" {
+  value       = local.enabled ? join("", aws_ec2_client_vpn_endpoint.default[*].id) : null
+  description = "The ID of the Client VPN Endpoint Connection."
 }


### PR DESCRIPTION
## what

This adds the outputs for the optionally created cloudwatch logs and the security group.

## why

In my use case, this information is useful to pass on to other modules, thus adding the outputs helps expose that information.

This also supersedes PR https://github.com/cloudposse/terraform-aws-ec2-client-vpn/pull/116
and closes issue https://github.com/cloudposse/terraform-aws-ec2-client-vpn/issues/91
